### PR TITLE
Homedir cfg

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,8 @@ The program emits the following help text when invoked with the `-h` or `--help`
 ```
 Usage: bambu-add-ip [-h|--help] [flags] [printer_ip]
 
-Sends the IP address of a BambuLab printer to port 2021/udp, where BambuStudio is listening
+Sends the IP address of your BambuLab printer to port 2021/udp,
+where BambuStudio is listening
 
 -h / --help   show this message
 -d / --debug  print additional debugging messages
@@ -44,7 +45,7 @@ Flags:
     (default: 000000000000000)
 --config-file CONFIG_FILE
     path to an optional config file which can be sourced to load the above settings
-    (default: ./config.env)
+    (default: /Users/user/.bambu-add-ip.cfg)
 
 Example config file content:
 SLICER_IP=127.0.0.1

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Flags:
     (default: 000000000000000)
 --config-file CONFIG_FILE
     path to an optional config file which can be sourced to load the above settings
-    (default: /Users/user/.bambu-add-ip.cfg)
+    (default: $HOME/.bambu-add-ip.cfg)
 
 Example config file content:
 SLICER_IP=127.0.0.1

--- a/bambu-add-ip.sh
+++ b/bambu-add-ip.sh
@@ -7,7 +7,7 @@ set -eu
 SELF=$(basename "$0" '.sh')
 
 # set defaults (see usage below for more info)
-CONFIG_FILE="${CONFIG_FILE:-$(dirname "$0")/config.env}"
+CONFIG_FILE="${CONFIG_FILE:-${HOME}/.${SELF}.cfg}"
 SLICER_IP="${SLICER_IP:-127.0.0.1}"
 PRINTER_IP="${PRINTER_IP:-}"
 PRINTER_USN="${PRINTER_USN:-000000000000000}"


### PR DESCRIPTION
changes the default config file location from `./config.env` to `${HOME}/.bambu-add-ip.cfg`, this makes it a little easier to run in a platypus context.